### PR TITLE
fixed: slow initial render

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,14 +50,19 @@ def classifyPath(hidden, fileType, groupBy) -> Dict[str, List[str]]:
         }
     )
 
+    """
+    Because of classifyMedia() the following that too much time for the initial render.
     classifyMedia(conn, pathOf("models/yolov8n.onnx"), populateMediaTable(conn, mediaPaths(homeDir())))
+    """
 
-    # Clear unavailable paths from DB
     cleanDB(conn)
 
     if groupBy == "directory":
+        populateMediaTable(conn, mediaPaths(homeDir()))
         result = groupByDir(conn, hidden, fileType)
     else:
+        populateMediaTable(conn, mediaPaths(homeDir()))
+        classifyMedia(conn, pathOf("models/yolov8n.onnx"), getUnlinkedMedia(conn))
         result = groupByClass(conn, hidden, fileType)
 
     closeConnection(conn)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def dbPath() -> str:
     os.makedirs(directory, exist_ok=True)
     return os.path.join(directory, "database.db")
 
-def classifyPath(hidden, fileType, groupBy) -> Dict[str, List[str]]:
+def groupPaths(hidden, fileType, groupBy) -> Dict[str, List[str]]:
     """
     Classify files in the home directory and store the results in the database.
 
@@ -92,19 +92,19 @@ def sendFile(path):
 def groupMedia(fileType, groupBy):
     if fileType not in ["img", "vid"] or groupBy not in ["class", "directory"]:
         return redirect(url_for('index'))
-    return render_template('index.html', classDict=classifyPath(0, fileType, groupBy))
+    return render_template('index.html', classDict=groupPaths(0, fileType, groupBy))
 
 @app.route('/hidden/<string:groupBy>')
 def hidden(groupBy):
     if groupBy not in ["class", "directory"]:
         return redirect(url_for('index'))
-    return render_template('index.html', classDict=classifyPath(1, "any", groupBy))
+    return render_template('index.html', classDict=groupPaths(1, "any", groupBy))
 
 @app.route('/trash/<string:groupBy>')
 def trash(groupBy):
     if groupBy not in ["class", "directory"]:
         return redirect(url_for('index'))
-    return render_template('index.html', classDict=classifyPath(-1, "any", groupBy))
+    return render_template('index.html', classDict=groupPaths(-1, "any", groupBy))
 
 # Buttons
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def processMedia(conn: sqlite3.Connection, files: Generator[str, None, None]) ->
         fileHash = genHash(file)
         if updateMediaPath(conn, file, fileHash):
             continue
-        rowsToClassify.append(populateMediaTable(conn, fileHash, file, parentDir, fileType))
+        rowsToClassify.append(insertMedia(conn, fileHash, file, parentDir, fileType))
     
     for mediaID, file, fileType in rowsToClassify:
         try:
@@ -46,7 +46,7 @@ def processMedia(conn: sqlite3.Connection, files: Generator[str, None, None]) ->
         except Exception as e:
             print(e)
             continue
-        relateClass(conn, mediaClass, mediaID)
+        insertClassRelation(conn, mediaClass, mediaID)
 
 def classifyPath(hidden, fileType, groupBy) -> Dict[str, List[str]]:
     """

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def classifyPath(hidden, fileType, groupBy) -> Dict[str, List[str]]:
         }
     )
 
-    classifyMedia(conn, populateMediaTable(conn, mediaPaths(homeDir())))
+    classifyMedia(conn, pathOf("models/yolov8n.onnx"), populateMediaTable(conn, mediaPaths(homeDir())))
 
     # Clear unavailable paths from DB
     cleanDB(conn)

--- a/media/__init__.py
+++ b/media/__init__.py
@@ -1,2 +1,3 @@
 from .image import imageClasses
 from .video import videoClasses
+from .process import populateMediaTable, classifyMedia

--- a/media/process.py
+++ b/media/process.py
@@ -16,14 +16,13 @@ def populateMediaTable(conn: sqlite3.Connection, files: Generator[Tuple[str, str
     Yields:
         Tuples containing mediaID, file, and fileType.
     """
-    objDetectionModel = pathOf("models/yolov8n.onnx")
     for file, fileType, parentDir in files:
         fileHash = genHash(file)
         if updateMediaPath(conn, file, parentDir, fileHash):
             continue
         yield insertMedia(conn, fileHash, file, parentDir, fileType)
 
-def classifyMedia(conn: sqlite3.Connection, rowsToClassify: Generator[Tuple[int, str, str], None, None]) -> None:
+def classifyMedia(conn: sqlite3.Connection, objDetectionModel: str, rowsToClassify: Generator[Tuple[int, str, str], None, None]) -> None:
     """
     Classify media files.
     Establish relation between media files and classes,

--- a/media/process.py
+++ b/media/process.py
@@ -32,7 +32,6 @@ def classifyMedia(conn: sqlite3.Connection, objDetectionModel: str, rowsToClassi
         conn: The database connection object.
         rowsToClassify: A generator of tuples containing mediaID, file, and fileType.
     """
-    objDetectionModel = pathOf("models/yolov8n.onnx")
     for mediaID, file, fileType in rowsToClassify:
         try:
             if fileType == "vid":

--- a/media/process.py
+++ b/media/process.py
@@ -1,0 +1,46 @@
+import sqlite3
+from typing import Generator, Tuple
+from utils import *
+from media import *
+
+def populateMediaTable(conn: sqlite3.Connection, files: Generator[Tuple[str, str, str], None, None]) -> Generator[Tuple[int, str, str], None, None]:
+    """
+    Generate file hash.
+    If hash already exists, update the path of existing media files.
+    Otherwise, insert data of new media files.
+
+    Args:
+        conn: The database connection object.
+        files: A generator of file paths.
+
+    Yields:
+        Tuples containing mediaID, file, and fileType.
+    """
+    objDetectionModel = pathOf("models/yolov8n.onnx")
+    for file, fileType, parentDir in files:
+        fileHash = genHash(file)
+        if updateMediaPath(conn, file, parentDir, fileHash):
+            continue
+        yield insertMedia(conn, fileHash, file, parentDir, fileType)
+
+def classifyMedia(conn: sqlite3.Connection, rowsToClassify: Generator[Tuple[int, str, str], None, None]) -> None:
+    """
+    Classify media files.
+    Establish relation between media files and classes,
+    By inserting result into Junction Table.
+
+    Args:
+        conn: The database connection object.
+        rowsToClassify: A generator of tuples containing mediaID, file, and fileType.
+    """
+    objDetectionModel = pathOf("models/yolov8n.onnx")
+    for mediaID, file, fileType in rowsToClassify:
+        try:
+            if fileType == "vid":
+                mediaClass = videoClasses(file, objDetectionModel)
+            elif fileType == "img":
+                mediaClass = imageClasses(file, objDetectionModel)
+        except Exception as e:
+            print(e)
+            continue
+        insertClassRelation(conn, mediaClass, mediaID)

--- a/media/process.py
+++ b/media/process.py
@@ -3,7 +3,7 @@ from typing import Generator, Tuple
 from utils import *
 from media import *
 
-def populateMediaTable(conn: sqlite3.Connection, files: Generator[Tuple[str, str, str], None, None]) -> Generator[Tuple[int, str, str], None, None]:
+def populateMediaTable(conn: sqlite3.Connection, files: Generator[Tuple[str, str, str], None, None]) -> None:
     """
     Generate file hash.
     If hash already exists, update the path of existing media files.
@@ -12,15 +12,18 @@ def populateMediaTable(conn: sqlite3.Connection, files: Generator[Tuple[str, str
     Args:
         conn: The database connection object.
         files: A generator of file paths.
-
-    Yields:
-        Tuples containing mediaID, file, and fileType.
     """
     for file, fileType, parentDir in files:
         fileHash = genHash(file)
         if updateMediaPath(conn, file, parentDir, fileHash):
             continue
+        insertMedia(conn, fileHash, file, parentDir, fileType)
+    """
+    We aren't passing this directly to classifyMedia().
+    Yields:
+        Generator[Tuple[int, str, str], None, None]: Tuples containing mediaID, file, and fileType.
         yield insertMedia(conn, fileHash, file, parentDir, fileType)
+    """
 
 def classifyMedia(conn: sqlite3.Connection, objDetectionModel: str, rowsToClassify: Generator[Tuple[int, str, str], None, None]) -> None:
     """

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
 
 from .fs import genHash, checkExtension, mediaPaths, homeDir, deleteFile, pathExist, pathOf
-from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, insertIntoDB, toggleVisibility, moveToTrash
+from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, populateMediaTable, relateClass, toggleVisibility, moveToTrash

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
 
 from .fs import genHash, checkExtension, mediaPaths, homeDir, deleteFile, pathExist, pathOf
-from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, insertMedia, insertClassRelation, toggleVisibility, moveToTrash
+from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, insertMedia, insertClassRelation, toggleVisibility, moveToTrash, getUnlinkedMedia

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
 
 from .fs import genHash, checkExtension, mediaPaths, homeDir, deleteFile, pathExist, pathOf
-from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, populateMediaTable, relateClass, toggleVisibility, moveToTrash
+from .db import createSchema, connectDB, createTable, closeConnection, groupByClass, groupByDir, updateMediaPath, hideByClass, deleteFromDB, cleanDB, insertMedia, insertClassRelation, toggleVisibility, moveToTrash

--- a/utils/db.py
+++ b/utils/db.py
@@ -272,21 +272,20 @@ def insertMedia(conn: sqlite3.Connection, fileHash: str, file: str, directory: s
 
     Returns:
         A tuple of mediaID, file, and fileType.
-    """
-    return [executeQuery(conn, "INSERT INTO MEDIA(hash, path, directory, fileType, hidden) VALUES(?, ?, ?, ?, 0)", [fileHash, file, directory, fileType]).lastrowid, file, fileType]
-
-def insertClassRelation(conn: sqlite3.Connection, mediaClass: List[str], mediaID) -> None:
-    """Inserts media and its classes into the database.
-
-    Args:
-        conn: sqlite3.Connection object.
-        file: The path to the media file.
-        mediaClass: A list of classes associated with the media.
-        fileHash: The hash value of the media.
 
     Note:
         No need to check if mediaID exist in Junction Table.
         updateMediaPath() won't allow older mediaIDs.
+    """
+    return [executeQuery(conn, "INSERT INTO MEDIA(hash, path, directory, fileType, hidden) VALUES(?, ?, ?, ?, 0)", [fileHash, file, directory, fileType]).lastrowid, file, fileType]
+
+def insertClassRelation(conn: sqlite3.Connection, mediaClass: List[str], mediaID) -> None:
+    """Populates the JUNCTION table with the given class information.
+
+    Args:
+        conn: sqlite3.Connection object.
+        mediaClass: A list of class names.
+        mediaID: The ID of the media file.
     """
     for className in mediaClass:
         try:

--- a/utils/db.py
+++ b/utils/db.py
@@ -247,8 +247,8 @@ def cleanDB(conn: sqlite3.Connection) -> None:
         print(paths)
         deleteFromDB(conn, paths)
 
-def updateMediaPath(conn, file, fileHash):
-    """Updates the path of a media file in the database.
+def updateMediaPath(conn, file, directory, fileHash):
+    """Updates the path and directoryof a media file in the database.
 
     Args:
         conn: sqlite3.Connection object.
@@ -258,7 +258,7 @@ def updateMediaPath(conn, file, fileHash):
     Returns:
         True if the path was updated, False otherwise.
     """
-    if executeQuery(conn, "UPDATE MEDIA SET path = ? WHERE hash = ?", [file, fileHash]).rowcount == 0:
+    if executeQuery(conn, "UPDATE MEDIA SET path = ?, directory = ? WHERE hash = ?", [file, directory, fileHash]).rowcount == 0:
         return False
     return True
 

--- a/utils/db.py
+++ b/utils/db.py
@@ -262,7 +262,7 @@ def updateMediaPath(conn, file, fileHash):
         return False
     return True
 
-def populateMediaTable(conn: sqlite3.Connection, fileHash: str, file: str, directory: str, fileType: str) -> Tuple[int, str, str]:
+def insertMedia(conn: sqlite3.Connection, fileHash: str, file: str, directory: str, fileType: str) -> Tuple[int, str, str]:
     """Populates the MEDIA table with the given file information.
 
     Args:
@@ -275,7 +275,7 @@ def populateMediaTable(conn: sqlite3.Connection, fileHash: str, file: str, direc
     """
     return [executeQuery(conn, "INSERT INTO MEDIA(hash, path, directory, fileType, hidden) VALUES(?, ?, ?, ?, 0)", [fileHash, file, directory, fileType]).lastrowid, file, fileType]
 
-def relateClass(conn: sqlite3.Connection, mediaClass: List[str], mediaID) -> None:
+def insertClassRelation(conn: sqlite3.Connection, mediaClass: List[str], mediaID) -> None:
     """Inserts media and its classes into the database.
 
     Args:

--- a/utils/db.py
+++ b/utils/db.py
@@ -277,7 +277,7 @@ def insertMedia(conn: sqlite3.Connection, fileHash: str, file: str, directory: s
         No need to check if mediaID exist in Junction Table.
         updateMediaPath() won't allow older mediaIDs.
     """
-    return [executeQuery(conn, "INSERT INTO MEDIA(hash, path, directory, fileType, hidden) VALUES(?, ?, ?, ?, 0)", [fileHash, file, directory, fileType]).lastrowid, file, fileType]
+    return executeQuery(conn, "INSERT INTO MEDIA(hash, path, directory, fileType, hidden) VALUES(?, ?, ?, ?, 0)", [fileHash, file, directory, fileType]).lastrowid, file, fileType
 
 def insertClassRelation(conn: sqlite3.Connection, mediaClass: List[str], mediaID) -> None:
     """Populates the JUNCTION table with the given class information.


### PR DESCRIPTION

- creation of Media table is separated from classification
- Initial render only needs the population of media table
- classification will be done when requested