### PR TITLE
[Add]: simulated click event instead of displayData()  

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -4,7 +4,7 @@ let currentMediaArray = [];
 let currentMediaTypesArray = [];
 let selectedMedia = [];
 let selectionMode = false;
-let section = localStorage.getItem('defaultSection') || "img";
+let section = localStorage.getItem('defaultSection') || null;
 let groupBy = "directory";
 let openedGroup = "";
 let fetchController;

--- a/static/index.js
+++ b/static/index.js
@@ -14,10 +14,10 @@ let isShowingInfo = false;
 const navConfig = {
     default: [
         { src: "/static/icons/ai.svg", alt: "AI Tags", class: "toggle", onclick: "toggleGroup(this)" },
-        { src: "/static/icons/images.svg", alt: "Images", class: "section", onclick: "displayData('img', this)" },
-        { src: "/static/icons/videos.svg", alt: "Videos", class: "section", onclick: "displayData('vid', this)" },
-        { src: "/static/icons/hide.svg", alt: "Hidden Files", class: "section", onclick: "displayData('hidden', this)" },
-        { src: "/static/icons/delete.svg", alt: "Trash", class: "section", onclick: "displayData('trash', this)" },
+        { src: "/static/icons/images.svg", alt: "Images", class: "section", id: "img", onclick: "displayData('img', this)" },
+        { src: "/static/icons/videos.svg", alt: "Videos", class: "section", id: "vid", onclick: "displayData('vid', this)" },
+        { src: "/static/icons/hide.svg", alt: "Hidden Files", class: "section", id: "hidden", onclick: "displayData('hidden', this)" },
+        { src: "/static/icons/delete.svg", alt: "Trash", class: "section", id: "trash", onclick: "displayData('trash', this)" },
         { src: "/static/icons/select.svg", alt: "Enable Selection Mode", class: "toggle", onclick: "toggleSelectionMode()" }
     ],
     selection: {
@@ -353,6 +353,8 @@ function updateNavbar(mode = 'default') {
         navIcon.title = item.alt;
         navIcon.className = item.class;
         navIcon.onclick = new Function(item.onclick);
+
+        if(item.id) navIcon.id = item.id
 
         const navItem = document.createElement('div');
         navItem.className = 'nav-icon';

--- a/static/index.js
+++ b/static/index.js
@@ -4,7 +4,7 @@ let currentMediaArray = [];
 let currentMediaTypesArray = [];
 let selectedMedia = [];
 let selectionMode = false;
-let section = localStorage.getItem('default') || "img";
+let section = localStorage.getItem('defaultSection') || "img";
 let groupBy = "directory";
 let openedGroup = "";
 let fetchController;
@@ -154,7 +154,7 @@ function handleMediaClick(pathsArray, typesArray, index) {
 // Display group cards with data
 async function displayData(_section, button) {
     section = _section;
-    localStorage.setItem('default', section)
+    localStorage.setItem('defaultSection', section)
 
     const data = await readRoute(`/${section}/${groupBy}`, button);
     const container = document.getElementById('dataContainer');

--- a/static/index.js
+++ b/static/index.js
@@ -4,7 +4,7 @@ let currentMediaArray = [];
 let currentMediaTypesArray = [];
 let selectedMedia = [];
 let selectionMode = false;
-let section = localStorage.getItem('defaultSection') || null;
+let section = localStorage.getItem('defaultSection') || "img";
 let groupBy = "directory";
 let openedGroup = "";
 let fetchController;

--- a/static/index.js
+++ b/static/index.js
@@ -52,8 +52,6 @@ const navConfig = {
 // Initial navbar
 requestAnimationFrame(updateNavbar);
 
-// Display default section
-displayData(section, null);
 
 // Fetch data from a route
 async function readRoute(route, button) {

--- a/static/index.js
+++ b/static/index.js
@@ -13,12 +13,12 @@ let isShowingInfo = false;
 // Navbar configuration
 const navConfig = {
     default: [
-        { src: "/static/icons/ai.svg", alt: "AI Tags", class: "toggle", onclick: "toggleGroup(this)" },
+        { src: "/static/icons/ai.svg", alt: "AI Tags", class: "toggle", id: "ai-tags", onclick: "toggleGroup(this)" },
         { src: "/static/icons/images.svg", alt: "Images", class: "section", id: "img", onclick: "displayData('img', this)" },
         { src: "/static/icons/videos.svg", alt: "Videos", class: "section", id: "vid", onclick: "displayData('vid', this)" },
         { src: "/static/icons/hide.svg", alt: "Hidden Files", class: "section", id: "hidden", onclick: "displayData('hidden', this)" },
         { src: "/static/icons/delete.svg", alt: "Trash", class: "section", id: "trash", onclick: "displayData('trash', this)" },
-        { src: "/static/icons/select.svg", alt: "Enable Selection Mode", class: "toggle", onclick: "toggleSelectionMode()" }
+        { src: "/static/icons/select.svg", alt: "Enable Selection Mode", class: "toggle", id: "selection-mode", onclick: "toggleSelectionMode()" }
     ],
     selection: {
         img: [
@@ -353,8 +353,7 @@ function updateNavbar(mode = 'default') {
         navIcon.title = item.alt;
         navIcon.className = item.class;
         navIcon.onclick = new Function(item.onclick);
-
-        if(item.id) navIcon.id = item.id
+        navIcon.id = item.id
 
         const navItem = document.createElement('div');
         navItem.className = 'nav-icon';

--- a/static/index.js
+++ b/static/index.js
@@ -353,7 +353,8 @@ function updateNavbar(mode = 'default') {
         navIcon.title = item.alt;
         navIcon.className = item.class;
         navIcon.onclick = new Function(item.onclick);
-        navIcon.id = item.id
+        
+        if(item.id) navIcon.id = item.id
 
         const navItem = document.createElement('div');
         navItem.className = 'nav-icon';

--- a/static/index.js
+++ b/static/index.js
@@ -4,7 +4,7 @@ let currentMediaArray = [];
 let currentMediaTypesArray = [];
 let selectedMedia = [];
 let selectionMode = false;
-let section = "img";
+let section = localStorage.getItem('default') || "img";
 let groupBy = "directory";
 let openedGroup = "";
 let fetchController;
@@ -51,7 +51,6 @@ const navConfig = {
 
 // Initial navbar
 requestAnimationFrame(updateNavbar);
-
 
 // Fetch data from a route
 async function readRoute(route, button) {
@@ -155,6 +154,8 @@ function handleMediaClick(pathsArray, typesArray, index) {
 // Display group cards with data
 async function displayData(_section, button) {
     section = _section;
+    localStorage.setItem('default', section)
+
     const data = await readRoute(`/${section}/${groupBy}`, button);
     const container = document.getElementById('dataContainer');
 

--- a/static/indicateNav.js
+++ b/static/indicateNav.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Get default section value
-    const defaultSectionValue = localStorage.getItem('default')
+    const defaultSectionValue = localStorage.getItem('defaultSection')
 
     // Highlight and display default navbar section upon page reload 
     requestAnimationFrame(() => {

--- a/static/indicateNav.js
+++ b/static/indicateNav.js
@@ -1,4 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
+    // Get default section value
+    const defaultSectionValue = localStorage.getItem('default')
+
+    // Highlight and display default navbar section upon page reload 
+    requestAnimationFrame(() => {
+        const defaultSection = document.getElementById(defaultSectionValue)
+        defaultSection.click()
+    })
+
+
     document.body.addEventListener('click', (event) => {
         const target = event.target;
 

--- a/static/indicateNav.js
+++ b/static/indicateNav.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    
     // Get default section value
-    const defaultSectionValue = localStorage.getItem('defaultSection')
+    const defaultSectionValue = section
 
     // Highlight and display default navbar section upon page reload 
     requestAnimationFrame(() => {

--- a/static/indicateNav.js
+++ b/static/indicateNav.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Highlight and display default navbar section upon page reload 
     requestAnimationFrame(() => {
+        if(!defaultSectionValue) return 
         const defaultSection = document.getElementById(defaultSectionValue)
         defaultSection.click()
     })


### PR DESCRIPTION
This PR adds functionality to ensure that the default navbar section is highlighted upon page reload, even if the user has not interacted with the navigation bar.

__Fixes #48__ 